### PR TITLE
PR: Hide popup scrollbar when its not needed

### DIFF
--- a/src/Visualizer/style/info-popup.scss
+++ b/src/Visualizer/style/info-popup.scss
@@ -19,7 +19,7 @@
     z-index: 200000;
     padding: 16px 16px 8px;
     transform: translateX(-50%) translateY(-50%);
-    overflow-y: scroll;
+    overflow-y: auto;
 
     border-radius: 8px;
 


### PR DESCRIPTION
Change:
CSS overflow-y for popup components has been updated from 'scroll' to 'auto'. Now, the scrollbar will only appear when the content overflows the popup container.

Reasons:
The scrollbar now only appears when needed, making the interface cleaner.

Confirmed working correctly in the following browsers:
Firefox 114.0.2
Edge 114.0.1823.67